### PR TITLE
fix: tab escaping

### DIFF
--- a/src/JsonSerializationWriter.php
+++ b/src/JsonSerializationWriter.php
@@ -45,7 +45,7 @@ class JsonSerializationWriter implements SerializationWriter
      */
     public function writeStringValue(?string $key, ?string $value): void {
 
-        $propertyValue = $value !== null ? '"'.addcslashes($value, "\\\r\n\"").'"' : '';
+        $propertyValue = $value !== null ? '"'.addcslashes($value, "\\\r\n\"\t").'"' : '';
         if ($value !== null) {
             if (!empty($key)) {
                 $this->writePropertyName($key);

--- a/tests/JsonSerializationWriterTest.php
+++ b/tests/JsonSerializationWriterTest.php
@@ -201,8 +201,8 @@ class JsonSerializationWriterTest extends TestCase
      */
     public function testWriteStringValue(): void {
         $this->jsonSerializationWriter = new JsonSerializationWriter();
-        $this->jsonSerializationWriter->writeAnyValue("statement", "This is a string");
-        $expected = '"statement":"This is a string"';
+        $this->jsonSerializationWriter->writeAnyValue("statement", "This is a string\n\r\t");
+        $expected = '"statement":"This is a string\\n\\r\\t"';
         $actual = $this->jsonSerializationWriter->getSerializedContent()->getContents();
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
I was getting `Control character error, possibly incorrectly encoded` errors when trying to `json_decode` the serialized json.