### PR TITLE
Fix PHPStan failure when getting object value from JsonParseNode

### DIFF
--- a/src/JsonParseNode.php
+++ b/src/JsonParseNode.php
@@ -104,7 +104,6 @@ class JsonParseNode implements ParseNode
         if (!is_callable($type, true, $callableString)) {
             throw new InvalidArgumentException('Undefined method '. $type[1]);
         }
-        /** @var Parsable $result */
         $result = $callableString($this);
         if($this->getOnBeforeAssignFieldValues() !== null) {
             $this->getOnBeforeAssignFieldValues()($result);


### PR DESCRIPTION
Using the generic PHPDoc tags added in https://github.com/microsoft/kiota-abstractions-php/pull/42 the expected return type after calling the Parsable factory method is an object that implements `Parsable`

PHPStan currently fails with:
```
------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   JsonParseNode.php                                                                                                                                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  :116   Method Microsoft\Kiota\Serialization\Json\JsonParseNode::getObjectValue() should return (T of Microsoft\Kiota\Abstractions\Serialization\Parsable)|null but returns Microsoft\Kiota\Abstractions\Serialization\Parsable.  
         💡 Type Microsoft\Kiota\Abstractions\Serialization\Parsable is not always the same as T. It breaks the contract for some argument types, typically subtypes.                                                               
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```