### PR TITLE
Support deserializing objects to stream

### DIFF
--- a/src/JsonParseNode.php
+++ b/src/JsonParseNode.php
@@ -284,6 +284,11 @@ class JsonParseNode implements ParseNode
     }
 
     public function getBinaryContent(): ?StreamInterface {
-        return ($this->jsonNode !== null) ? Utils::streamFor(strval($this->jsonNode)) : null;
+        if (is_null($this->jsonNode)) {
+            return null;
+        } else if (is_array($this->jsonNode)) {
+            return Utils::streamFor(json_encode($this->jsonNode));
+        }
+        return Utils::streamFor(strval($this->jsonNode));
     }
 }


### PR DESCRIPTION
When making batch requests, we need to deserialize an individual JSON response payload to a stream in the [BatchResponseItem](https://github.com/microsoftgraph/msgraph-sdk-php-core/blob/dev/src/Requests/BatchResponseItem.php#L42). We store the payload as a stream as we don't know the correct type to deserialize to beforehand.