### PR TITLE
DateTime format already contains timezone info

### DIFF
--- a/src/JsonSerializationWriter.php
+++ b/src/JsonSerializationWriter.php
@@ -100,7 +100,7 @@ class JsonSerializationWriter implements SerializationWriter
             if (!empty($key)) {
                 $this->writePropertyName($key);
             }
-            $this->writePropertyValue($key, "\"{$value->format(DateTimeInterface::RFC3339)}Z\"");
+            $this->writePropertyValue($key, "\"{$value->format(DateTimeInterface::RFC3339)}\"");
         }
     }
 

--- a/tests/JsonSerializationWriterTest.php
+++ b/tests/JsonSerializationWriterTest.php
@@ -183,10 +183,10 @@ class JsonSerializationWriterTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testWriteDateTimeOffsetValue(): void {
+    public function testWriteDateTimeValue(): void {
         $this->jsonSerializationWriter = new JsonSerializationWriter();
-        $this->jsonSerializationWriter->writeAnyValue("dateTime", new \DateTime('2018-12-12T12:34:42+00:00Z'));
-        $expected = '"dateTime":"2018-12-12T12:34:42+00:00Z"';
+        $this->jsonSerializationWriter->writeAnyValue("dateTime", new \DateTime('2018-12-12T12:34:42+00:00'));
+        $expected = '"dateTime":"2018-12-12T12:34:42+00:00"';
         $actual = $this->jsonSerializationWriter->getSerializedContent()->getContents();
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
`RFC3339` format already contains the timezone info while `Z` denotes UTC time where `2019-10-12T07:20:50.52Z` is the same as `2019-10-12T07:20:50.52+00:00`

closes #33