### PR TITLE
Refactor code to never do casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.3.0]
+
+### Added
+
+### Changed
+- fix(logic): Don't cast types since this might introduce some logical bugs. Make sure values match possible values for that type.
+
 ## [1.0.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ run `composer require microsoft/kiota-serialization-json` or add the following t
 ```Shell
 {
     "require": {
-        "microsoft/kiota-serialization-json": "^1.0.1"
+        "microsoft/kiota-serialization-json": "^1.3.0"
     }
 }
 ```

--- a/src/JsonParseNode.php
+++ b/src/JsonParseNode.php
@@ -53,28 +53,28 @@ class JsonParseNode implements ParseNode
      * @inheritDoc
      */
     public function getStringValue(): ?string {
-        return $this->jsonNode !== null ? addcslashes(strval($this->jsonNode), "\\\r\n") : null;
+        return is_string($this->jsonNode) ? addcslashes($this->jsonNode, "\\\r\n") : null;
     }
 
     /**
      * @inheritDoc
      */
     public function getBooleanValue(): ?bool {
-        return $this->jsonNode !== null ? (bool)$this->jsonNode : null;
+        return is_bool($this->jsonNode) ? $this->jsonNode : null;
     }
 
     /**
      * @inheritDoc
      */
     public function getIntegerValue(): ?int {
-        return $this->jsonNode !== null ? intval($this->jsonNode) : null;
+        return is_int($this->jsonNode) ? $this->jsonNode : null;
     }
 
     /**
      * @inheritDoc
      */
     public function getFloatValue(): ?float {
-        return $this->jsonNode !== null ? floatval($this->jsonNode) : null;
+        return is_float($this->jsonNode) ? $this->jsonNode : null;
     }
 
     /**

--- a/tests/JsonParseNodeTest.php
+++ b/tests/JsonParseNodeTest.php
@@ -29,9 +29,11 @@ class JsonParseNodeTest extends TestCase
     }
 
     public function testGetIntegerValue(): void {
-        $this->parseNode = new JsonParseNode('1243.78');
+        $this->parseNode = new JsonParseNode(1243.78);
         $expected = $this->parseNode->getIntegerValue();
-        $this->assertEquals(1243, $expected);
+        $this->assertEquals(null, $expected);
+        $this->parseNode = new JsonParseNode(1243);
+        $this->assertEquals(1243, $this->parseNode->getIntegerValue());
     }
 
     public function testGetCollectionOfObjectValues(): void {
@@ -61,7 +63,7 @@ class JsonParseNodeTest extends TestCase
     }
 
     public function testGetFloatValue(): void {
-        $this->parseNode = new JsonParseNode('1243.12');
+        $this->parseNode = new JsonParseNode(1243.12);
         $expected = $this->parseNode->getFloatValue();
         $this->assertEquals(1243.12, $expected);
     }


### PR DESCRIPTION
Given the code
```php
if ($parseNode->getBooleanValue() !== null) {
    $result->setBoolean($parseNode->getBooleanValue());
} else if ($parseNode->getFloatValue() !== null) {
    $result->setDouble($parseNode->getFloatValue());
} else if ($parseNode->getIntegerValue() !== null) {
    $result->setInteger($parseNode->getIntegerValue());
} else if ($parseNode->getStringValue() !== null) {
    $result->setString($parseNode->getStringValue());
}
```


With the current ParseNode implementation, the code will always never go to other branches of the if (unless `getBooleanValue()` returns null) since anything can be cast to boolean making the first branch of the if always true.

This work is part of
https://github.com/microsoft/kiota/issues/2827
https://github.com/microsoft/kiota-serialization-json-php/pull/73
