### PR TITLE
Use main as default branch

### DIFF
--- a/.github/policies/kiota-serialization-json-php-branch-protection.yml
+++ b/.github/policies/kiota-serialization-json-php-branch-protection.yml
@@ -7,9 +7,7 @@ resource: repository
 configuration:
   branchProtectionRules:
 
-  - branchNamePattern: dev
-    # This branch pattern applies to the following branches as of 06/09/2023 14:08:44:
-    # dev
+  - branchNamePattern: main
 
     # Specifies whether this branch can be deleted. boolean
     allowsDeletions: false

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
`main` is now up to date with `dev`: https://github.com/microsoft/kiota-serialization-json-php/compare/main...dev

cc: @baywet for deletion of `dev` & making `main` default