### PR TITLE
Fix data loss with null being returned on int numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.3.1]
+
+### Added
+
+### Changed
+- fix(serialization): Float serialization also accepts integer values. [#85](https://github.com/microsoft/kiota-serialization-json-php/pull/85)
+
 ## [1.3.0]
 
 ### Added

--- a/src/JsonParseNode.php
+++ b/src/JsonParseNode.php
@@ -74,7 +74,7 @@ class JsonParseNode implements ParseNode
      * @inheritDoc
      */
     public function getFloatValue(): ?float {
-        return is_float($this->jsonNode) ? $this->jsonNode : null;
+        return is_float($this->jsonNode) || is_int($this->jsonNode) ? floatval($this->jsonNode) : null;
     }
 
     /**

--- a/src/JsonParseNode.php
+++ b/src/JsonParseNode.php
@@ -74,7 +74,13 @@ class JsonParseNode implements ParseNode
      * @inheritDoc
      */
     public function getFloatValue(): ?float {
-        return is_float($this->jsonNode) || is_int($this->jsonNode) ? floatval($this->jsonNode) : null;
+        if (is_float($this->jsonNode)) {
+            return $this->jsonNode;
+        }
+        if (is_int($this->jsonNode)) {
+            return floatval($this->jsonNode);
+        }
+        return null;
     }
 
     /**

--- a/tests/JsonParseNodeTest.php
+++ b/tests/JsonParseNodeTest.php
@@ -69,9 +69,9 @@ class JsonParseNodeTest extends TestCase
     }
 
     public function testGetFloatValueWithInt(): void {
-        $this->parseNode = new JsonParseNode(1);
+        $this->parseNode = new JsonParseNode(1243);
         $expected = $this->parseNode->getFloatValue();
-        $this->assertEquals(1.00, $expected);
+        $this->assertEquals(1243.00, $expected);
     }
 
     /**

--- a/tests/JsonParseNodeTest.php
+++ b/tests/JsonParseNodeTest.php
@@ -62,10 +62,16 @@ class JsonParseNodeTest extends TestCase
         $this->assertEquals(123.122, $expected->getHeight());
     }
 
-    public function testGetFloatValue(): void {
+    public function testGetFloatValueWithFloat(): void {
         $this->parseNode = new JsonParseNode(1243.12);
         $expected = $this->parseNode->getFloatValue();
         $this->assertEquals(1243.12, $expected);
+    }
+
+    public function testGetFloatValueWithInt(): void {
+        $this->parseNode = new JsonParseNode(1);
+        $expected = $this->parseNode->getFloatValue();
+        $this->assertEquals(1.00, $expected);
     }
 
     /**


### PR DESCRIPTION
Fix the cases where an integer number is being rejected by the float parser. With these changes, the float parser accepts an integer number and returns it as a float.

Fixes microsoft/kiota-serialization-json-php#86